### PR TITLE
Fix unit tests on i386

### DIFF
--- a/test/epoll-test.c
+++ b/test/epoll-test.c
@@ -222,12 +222,9 @@ ATF_TC_WITHOUT_HEAD(epoll__event_size);
 ATF_TC_BODY_FD_LEAKCHECK(epoll__event_size, tc)
 {
 	struct epoll_event event;
-#if defined(__amd64__)
+	// this check works on 32bit _and_ 64bit, since
+	// sizeof(epoll_event) == sizeof(uint32_t) + sizeof(uint64_t)
 	ATF_REQUIRE(sizeof(event) == 12);
-#else
-	// TODO(jan): test for other architectures
-	abort();
-#endif
 }
 
 static void

--- a/test/tst-eventfd.c
+++ b/test/tst-eventfd.c
@@ -351,8 +351,8 @@ int poll_test(void)
     /* write to event and check read poll */
     c = 1;
     s = write(efd, &c, sizeof(c));
-    if (s != sizeof(s)) {
-        handle_error("");
+    if (s != sizeof(c)) {
+        handle_error("failed to write event.");
     }
 
 #ifndef __FreeBSD__


### PR DESCRIPTION
epoll-test: Struct size is the same on 32bit and 64bit.
tst-eventfd: Test was checking the size of the wrong variable, added error text on failure.