### PR TITLE
Set FD_CLOEXEC on the kqueue file descriptor when requested

### DIFF
--- a/src/epoll.c
+++ b/src/epoll.c
@@ -33,11 +33,11 @@ static FDContextVTable const epollfd_vtable = {
 };
 
 static FDContextMapNode *
-epoll_create_impl(errno_t *ec)
+epoll_create_impl(errno_t *ec, bool cloexec)
 {
 	FDContextMapNode *node;
 
-	node = epoll_shim_ctx_create_node(&epoll_shim_ctx, ec);
+	node = epoll_shim_ctx_create_node(&epoll_shim_ctx, ec, cloexec);
 	if (!node) {
 		return NULL;
 	}
@@ -59,12 +59,12 @@ fail:
 }
 
 static int
-epoll_create_common(void)
+epoll_create_common(bool cloexec)
 {
 	FDContextMapNode *node;
 	errno_t ec;
 
-	node = epoll_create_impl(&ec);
+	node = epoll_create_impl(&ec, cloexec);
 	if (!node) {
 		errno = ec;
 		return -1;
@@ -82,7 +82,7 @@ epoll_create(int size)
 		return -1;
 	}
 
-	return epoll_create_common();
+	return epoll_create_common(false);
 }
 
 EPOLL_SHIM_EXPORT
@@ -94,7 +94,7 @@ epoll_create1(int flags)
 		return -1;
 	}
 
-	return epoll_create_common();
+	return epoll_create_common((flags & EPOLL_CLOEXEC) != 0);
 }
 
 static errno_t

--- a/src/epoll_shim_ctx.c
+++ b/src/epoll_shim_ctx.c
@@ -165,7 +165,8 @@ epoll_shim_ctx_create_node_impl(EpollShimCtx *epoll_shim_ctx, int kq,
 }
 
 FDContextMapNode *
-epoll_shim_ctx_create_node(EpollShimCtx *epoll_shim_ctx, errno_t *ec)
+epoll_shim_ctx_create_node(
+    EpollShimCtx *epoll_shim_ctx, errno_t *ec, bool cloexec)
 {
 	FDContextMapNode *node;
 
@@ -173,6 +174,12 @@ epoll_shim_ctx_create_node(EpollShimCtx *epoll_shim_ctx, errno_t *ec)
 	if (kq < 0) {
 		*ec = errno;
 		return NULL;
+	}
+	if (cloexec) {
+		int flags;
+
+		flags = fcntl(kq, F_GETFD);
+		fcntl(kq, F_SETFD, flags | FD_CLOEXEC);
 	}
 
 	(void)pthread_mutex_lock(&epoll_shim_ctx->mutex);

--- a/src/epoll_shim_ctx.h
+++ b/src/epoll_shim_ctx.h
@@ -61,8 +61,8 @@ typedef struct {
 
 extern EpollShimCtx epoll_shim_ctx;
 
-FDContextMapNode *epoll_shim_ctx_create_node(EpollShimCtx *epoll_shim_ctx,
-    errno_t *ec);
+FDContextMapNode *epoll_shim_ctx_create_node(
+    EpollShimCtx *epoll_shim_ctx, errno_t *ec, bool cloexec);
 FDContextMapNode *epoll_shim_ctx_find_node(EpollShimCtx *epoll_shim_ctx,
     int fd);
 FDContextMapNode *epoll_shim_ctx_remove_node(EpollShimCtx *epoll_shim_ctx,

--- a/src/eventfd.c
+++ b/src/eventfd.c
@@ -104,7 +104,8 @@ eventfd_impl(unsigned int initval, int flags, errno_t *ec)
 	 * will always be CLOEXEC.
 	 */
 
-	node = epoll_shim_ctx_create_node(&epoll_shim_ctx, ec);
+	node = epoll_shim_ctx_create_node(
+	    &epoll_shim_ctx, ec, (flags & EFD_CLOEXEC) != 0);
 	if (!node) {
 		return NULL;
 	}

--- a/src/signalfd.c
+++ b/src/signalfd.c
@@ -117,7 +117,8 @@ signalfd_impl(int fd, const sigset_t *sigs, int flags, errno_t *ec)
 		return NULL;
 	}
 
-	node = epoll_shim_ctx_create_node(&epoll_shim_ctx, ec);
+	node = epoll_shim_ctx_create_node(
+	    &epoll_shim_ctx, ec, (flags & SFD_CLOEXEC) != 0);
 	if (!node) {
 		return NULL;
 	}

--- a/src/timerfd.c
+++ b/src/timerfd.c
@@ -83,7 +83,8 @@ timerfd_create_impl(int clockid, int flags, errno_t *ec)
 		return NULL;
 	}
 
-	node = epoll_shim_ctx_create_node(&epoll_shim_ctx, ec);
+	node = epoll_shim_ctx_create_node(
+	    &epoll_shim_ctx, ec, (flags & TFD_CLOEXEC) != 0);
 	if (!node) {
 		return NULL;
 	}


### PR DESCRIPTION
This fixes one of the wayland tests on FreeBSD. This test calls execve()
without calling fork() first, so the kqueue file descriptor remains open.
Fix this by running `fcntl(kq, F_SETFD, flags | FD_CLOEXEC)` if one of
the CLOEXEC flags was passed.