### PR TITLE
Fix two memory leaks in tests

### DIFF
--- a/test/epoll-test.c
+++ b/test/epoll-test.c
@@ -200,6 +200,7 @@ ATF_TC_BODY_FD_LEAKCHECK(epoll__fd_exhaustion, tc)
 		--i;
 		ATF_REQUIRE(close(fds[i]) == 0);
 	}
+	free(fds);
 }
 
 ATF_TC_WITHOUT_HEAD(epoll__invalid_op);

--- a/test/perf-many-fds.c
+++ b/test/perf-many-fds.c
@@ -37,6 +37,7 @@ ATF_TC_BODY(perf_many_fds__perf, tc)
 			fprintf(stderr, ".");
 		}
 	}
+	free(eventfds);
 }
 
 ATF_TP_ADD_TCS(tp)


### PR DESCRIPTION
Found by running the tests with -fsanitize=address