### PR TITLE
Add support for CheriBSD

### DIFF
--- a/external/microatf/cmake/ATFTest.cmake
+++ b/external/microatf/cmake/ATFTest.cmake
@@ -16,6 +16,11 @@ function(atf_discover_tests _target)
     TARGET "${_target}"
     PROPERTY CROSSCOMPILING_EMULATOR)
 
+  if(CMAKE_CROSSCOMPILING AND NOT _test_executor)
+    message(WARNING "Cannot detect tests for ${_target} without CROSSCOMPILING_EMULATOR")
+    return()
+  endif()
+
   add_custom_command(
     TARGET ${_target}
     POST_BUILD

--- a/external/microatf/src/atf-c.c
+++ b/external/microatf/src/atf-c.c
@@ -76,14 +76,16 @@ static microatf_context_t microatf_context_static;
 static microatf_context_t *microatf_context = &microatf_context_static;
 
 struct atf_tc_impl_s_ {
+	size_t variables_size;
+	size_t config_variables_size;
 	char const *variables_key[128];
 	char const *variables_value[128];
-	size_t variables_size;
 	char const *config_variables_key[128];
 	char const *config_variables_value[128];
-	size_t config_variables_size;
 	STAILQ_ENTRY(atf_tc_s) entries;
 };
+_Static_assert(sizeof(atf_tc_t) - offsetof(atf_tc_t, impl_space_) >=
+    sizeof(struct atf_tc_impl_s_), "struct atf_tc_s is too small");
 
 atf_error_t
 atf_tc_set_md_var(atf_tc_t *tc, char const *key, char const *value, ...)

--- a/external/microatf/src/atf-c.h
+++ b/external/microatf/src/atf-c.h
@@ -36,12 +36,13 @@ typedef struct atf_tc_s atf_tc_t;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wpedantic"
+#define ATF_IMPL_SIZE (2 * sizeof(size_t) + 513 * sizeof(void*))
 struct atf_tc_s {
-	MICROATF_ALIGNAS(8192) char const *name;
+	char const *name;
 	void (*head)(atf_tc_t *);
 	void (*body)(atf_tc_t const *);
 	struct atf_tc_impl_s_ *impl_;
-	MICROATF_ALIGNAS(max_align_t) unsigned char impl_space_[];
+	MICROATF_ALIGNAS(max_align_t) unsigned char impl_space_[ATF_IMPL_SIZE];
 };
 #pragma GCC diagnostic pop
 
@@ -143,6 +144,7 @@ void atf_tc_skip(const char *reason, ...);
 		NULL,                                          \
 		microatf_tc_##tc##_body,                       \
 		NULL,                                          \
+		{}                                             \
 	}
 
 #define ATF_TC(tc)                                             \
@@ -153,6 +155,7 @@ void atf_tc_skip(const char *reason, ...);
 		microatf_tc_##tc##_head,                       \
 		microatf_tc_##tc##_body,                       \
 		NULL,                                          \
+		{}                                             \
 	}
 
 #define ATF_TC_HEAD(tc, tcptr)               \

--- a/src/compat_kqueue1.c
+++ b/src/compat_kqueue1.c
@@ -32,7 +32,7 @@ compat_kqueue1_impl(int *fd_out, int flags)
 		int r;
 
 		if (flags & O_CLOEXEC) {
-			if ((r = real_fcntl(fd, F_GETFD)) < 0 ||
+			if ((r = real_fcntl(fd, F_GETFD, 0)) < 0 ||
 			    real_fcntl(fd, F_SETFD, r | FD_CLOEXEC) < 0) {
 				ec = errno;
 				goto out;
@@ -49,7 +49,7 @@ compat_kqueue1_impl(int *fd_out, int flags)
 #endif
 
 		if (flags & O_NONBLOCK) {
-			if ((r = real_fcntl(fd, F_GETFL)) < 0) {
+			if ((r = real_fcntl(fd, F_GETFL, 0)) < 0) {
 				ec = errno;
 				goto out;
 			}

--- a/src/epoll.c
+++ b/src/epoll.c
@@ -18,6 +18,18 @@
 #include "timespec_util.h"
 #include "wrap.h"
 
+_Static_assert(POLLIN == EPOLLIN, "");
+_Static_assert(POLLPRI == EPOLLPRI, "");
+_Static_assert(POLLOUT == EPOLLOUT, "");
+_Static_assert(POLLERR == EPOLLERR, "");
+_Static_assert(POLLHUP == EPOLLHUP, "");
+#ifdef EPOLLNVAL
+_Static_assert(POLLNVAL == EPOLLNVAL, "");
+#endif
+#ifdef POLLRDHUP
+_Static_assert(POLLRDHUP == EPOLLRDHUP, "");
+#endif
+
 void epollfd_lock(FileDescription *desc);
 void epollfd_unlock(FileDescription *desc);
 void epollfd_remove_fd(FileDescription *desc, int kq, int fd);

--- a/src/epoll_shim_ctx.h
+++ b/src/epoll_shim_ctx.h
@@ -4,6 +4,7 @@
 #include <sys/tree.h>
 
 #include <stdatomic.h>
+#include <stdarg.h>
 
 #include <signal.h>
 #include <unistd.h>
@@ -82,6 +83,7 @@ int epoll_shim_poll(struct pollfd *, nfds_t, int);
 int epoll_shim_ppoll(struct pollfd *, nfds_t, struct timespec const *,
     sigset_t const *);
 
+intptr_t epoll_shim_fcntl_optional_arg(int cmd, va_list ap);
 int epoll_shim_fcntl(int fd, int cmd, ...);
 
 #endif

--- a/src/epoll_shim_interpose.c
+++ b/src/epoll_shim_interpose.c
@@ -6,14 +6,7 @@
 #include <unistd.h>
 
 #include "epoll_shim_interpose_export.h"
-
-int epoll_shim_close(int fd);
-ssize_t epoll_shim_read(int fd, void *buf, size_t nbytes);
-ssize_t epoll_shim_write(int fd, void const *buf, size_t nbytes);
-int epoll_shim_poll(struct pollfd *, nfds_t, int);
-int epoll_shim_ppoll(struct pollfd *, nfds_t, struct timespec const *,
-    sigset_t const *);
-int epoll_shim_fcntl(int fd, int cmd, ...);
+#include "epoll_shim_ctx.h"
 
 EPOLL_SHIM_INTERPOSE_EXPORT
 ssize_t
@@ -63,11 +56,12 @@ int
 fcntl(int fd, int cmd, ...)
 {
 	va_list ap;
+	intptr_t arg;
 
 	va_start(ap, cmd);
-	void *arg = va_arg(ap, void *);
-	int rv = epoll_shim_fcntl(fd, cmd, arg);
+	arg = epoll_shim_fcntl_optional_arg(cmd, ap);
 	va_end(ap);
+	int rv = epoll_shim_fcntl(fd, cmd, arg);
 
 	return rv;
 }

--- a/src/epollfd_ctx.c
+++ b/src/epollfd_ctx.c
@@ -1139,7 +1139,7 @@ epollfd_ctx_add_node(EpollFDCtx *epollfd, int kq, int fd2,
 		} else {
 			fd2_node->node_type = NODE_TYPE_FIFO;
 
-			int fl = real_fcntl(fd2, F_GETFL);
+			int fl = real_fcntl(fd2, F_GETFL, 0);
 			if (fl < 0) {
 				errno_t ec = errno;
 				registered_fds_node_destroy(fd2_node);

--- a/src/timerfd_ctx.c
+++ b/src/timerfd_ctx.c
@@ -614,7 +614,7 @@ timerfd_ctx_read(TimerFDCtx *timerfd, int kq, uint64_t *value)
 	}
 
 	bool got_kevent = false;
-	unsigned long event_ident;
+	uintptr_t event_ident;
 	{
 		struct kevent kevs[3];
 		int n = kevent(kq, NULL, 0, kevs, 3,

--- a/src/wrap.c
+++ b/src/wrap.c
@@ -124,15 +124,9 @@ real_ppoll(struct pollfd fds[], nfds_t nfds,
 }
 
 int
-real_fcntl(int fd, int cmd, ...)
+real_fcntl(int fd, int cmd, intptr_t arg)
 {
 	wrap_initialize();
-	va_list ap;
-
-	va_start(ap, cmd);
-	void *arg = va_arg(ap, void *);
 	int rv = wrap.real_fcntl(fd, cmd, arg);
-	va_end(ap);
-
 	return rv;
 }

--- a/src/wrap.h
+++ b/src/wrap.h
@@ -14,6 +14,6 @@ int real_poll(struct pollfd fds[], nfds_t nfds, int timeout);
 int real_ppoll(struct pollfd fds[], nfds_t nfds,
     struct timespec const *restrict timeout,
     sigset_t const *restrict newsigmask);
-int real_fcntl(int fd, int cmd, ...);
+int real_fcntl(int fd, int cmd, intptr_t);
 
 #endif

--- a/test/epoll-test.c
+++ b/test/epoll-test.c
@@ -164,22 +164,6 @@ ATF_TC_BODY_FD_LEAKCHECK(epoll__simple, tc)
 	ATF_REQUIRE_ERRNO(EINVAL, epoll_create1(42) < 0);
 }
 
-ATF_TC_WITHOUT_HEAD(epoll__poll_flags);
-ATF_TC_BODY_FD_LEAKCHECK(epoll__poll_flags, tc)
-{
-	ATF_REQUIRE(POLLIN == EPOLLIN);
-	ATF_REQUIRE(POLLPRI == EPOLLPRI);
-	ATF_REQUIRE(POLLOUT == EPOLLOUT);
-	ATF_REQUIRE(POLLERR == EPOLLERR);
-	ATF_REQUIRE(POLLHUP == EPOLLHUP);
-#ifdef EPOLLNVAL
-	ATF_REQUIRE(POLLNVAL == EPOLLNVAL);
-#endif
-#ifdef POLLRDHUP
-	ATF_REQUIRE(POLLRDHUP == EPOLLRDHUP);
-#endif
-}
-
 ATF_TC_WITHOUT_HEAD(epoll__leakcheck);
 ATF_TC_BODY_FD_LEAKCHECK(epoll__leakcheck, tc)
 {
@@ -2122,9 +2106,6 @@ ATF_TC_BODY_FD_LEAKCHECK(epoll__fcntl_fl, tcptr)
 ATF_TP_ADD_TCS(tp)
 {
 	ATF_TP_ADD_TC(tp, epoll__simple);
-#ifndef USE_EPOLLRDHUP_LINUX_DEFINITION
-	ATF_TP_ADD_TC(tp, epoll__poll_flags);
-#endif
 	ATF_TP_ADD_TC(tp, epoll__leakcheck);
 	ATF_TP_ADD_TC(tp, epoll__fd_exhaustion);
 	ATF_TP_ADD_TC(tp, epoll__invalid_op);

--- a/test/epoll-test.c
+++ b/test/epoll-test.c
@@ -377,7 +377,12 @@ ATF_TC_BODY_FD_LEAKCHECK(epoll__event_size, tc)
 	struct epoll_event event;
 	// this check works on 32bit _and_ 64bit, since
 	// sizeof(epoll_event) == sizeof(uint32_t) + sizeof(uint64_t)
+#if __SIZEOF_POINTER__ <= 8
 	ATF_REQUIRE(sizeof(event) == 12);
+#else
+	/* On systems with 128-bit pointers, it will be padded to 32 bytes */
+	ATF_REQUIRE(sizeof(event) == 2 * sizeof(void*));
+#endif
 }
 
 ATF_TC_WITHOUT_HEAD(epoll__recursive_register);
@@ -1231,7 +1236,9 @@ ATF_TC_BODY_FD_LEAKCHECK(epoll__epollpri, tcptr)
 	fd_tcp_socket(fds);
 
 	ATF_REQUIRE(fcntl(fds[0], F_SETFL, O_NONBLOCK) == 0);
+	ATF_REQUIRE(fcntl(fds[0], F_GETFL) & O_NONBLOCK);
 	ATF_REQUIRE(fcntl(fds[1], F_SETFL, O_NONBLOCK) == 0);
+	ATF_REQUIRE(fcntl(fds[1], F_GETFL) & O_NONBLOCK);
 
 	int ep = epoll_create1(EPOLL_CLOEXEC);
 	ATF_REQUIRE(ep >= 0);

--- a/test/timerfd-test.c
+++ b/test/timerfd-test.c
@@ -943,6 +943,7 @@ check:
 ATF_TC_WITHOUT_HEAD(timerfd__unmodified_errno);
 ATF_TC_BODY_FD_LEAKCHECK(timerfd__unmodified_errno, tc)
 {
+	ATF_REQUIRE(errno == 0);
 	int timerfd = timerfd_create(CLOCK_MONOTONIC, /**/
 	    TFD_CLOEXEC | TFD_NONBLOCK);
 	ATF_REQUIRE(timerfd >= 0);
@@ -954,6 +955,7 @@ ATF_TC_BODY_FD_LEAKCHECK(timerfd__unmodified_errno, tc)
 			    .it_value.tv_nsec = 100000000,
 			},
 			NULL) == 0);
+	ATF_REQUIRE(errno == 0);
 	(void)wait_for_timerfd(timerfd);
 	ATF_REQUIRE(errno == 0);
 
@@ -980,6 +982,7 @@ ATF_TC_BODY_FD_LEAKCHECK(timerfd__unmodified_errno, tc)
 ATF_TC_WITHOUT_HEAD(timerfd__reset_to_very_long);
 ATF_TC_BODY_FD_LEAKCHECK(timerfd__reset_to_very_long, tc)
 {
+	ATF_REQUIRE(errno == 0);
 	int timerfd = timerfd_create(CLOCK_MONOTONIC, /**/
 	    TFD_CLOEXEC | TFD_NONBLOCK);
 	ATF_REQUIRE(timerfd >= 0);


### PR DESCRIPTION
I tried running the tests on my Morello board and noticed that most of them were failing. This patch series makes epoll-shim work correctly when running on [CheriBSD](https://github.com/CTSRD-CHERI/cheribsd) (a fork of FreeBSD that adds support for CHERI-enabled architectures such as CHERI-RISC-V and Arm Morello).

With this patch series all but two tests pass for me and the last remaining failures will go away once https://github.com/CTSRD-CHERI/cheribsd/issues/1424 has been fixed.