### PR TITLE
Make sure the interpose package config file also includes the directory where the proper epoll-shim header files are located.

### DIFF
--- a/epoll-shim-interpose.pc.cmakein
+++ b/epoll-shim-interpose.pc.cmakein
@@ -9,4 +9,4 @@ Description: Small epoll implementation using kqueue (interposing wrapper)
 Version: 
 Requires: epoll-shim
 Libs: -L${libdir} -lepoll-shim-interpose
-Cflags: -DEPOLL_SHIM_DISABLE_WRAPPER_MACROS
+Cflags: -I${includedir}/libepoll-shim -DEPOLL_SHIM_DISABLE_WRAPPER_MACROS


### PR DESCRIPTION
Signed-off-by: Hans Petter Selasky <hps@selasky.org>