### PR TITLE
CI: upgrade FreeBSD version to avoid future breakage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Test in FreeBSD
       id: test
-      uses: vmactions/freebsd-vm@v0.1.6
+      uses: vmactions/freebsd-vm@v0.1.7
       with:
         envs: 'BUILD_TYPE'
         usesh: true


### PR DESCRIPTION
FreeBSD Project currently doesn't keep recent binary packages for EOL versions. `/release_0` packages (non-default) frozen at 13.0 release (2021-04-13) will remain after 13.0 EOL (2022-08-31) for 13.* branch lifetime (until 2026-01-31) but maybe too old for epoll-shim CI.