### PR TITLE
Use CMAKE_INSTALL_FULL_* in pc files

### DIFF
--- a/epoll-shim-interpose.pc.cmakein
+++ b/epoll-shim-interpose.pc.cmakein
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: epoll-shim-interpose
 URL: https://github.com/jiixyj/epoll-shim

--- a/epoll-shim.pc.cmakein
+++ b/epoll-shim.pc.cmakein
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: epoll-shim
 URL: https://github.com/jiixyj/epoll-shim


### PR DESCRIPTION
It's valid for libdir and includedir to not be subdirectories of exec_prefix and prefix.  In [Nixpkgs](https://github.com/NixOS/nixpkgs), this is how we handle split packages — binaries get installed to one unique prefix, and libraries to another.  With this change, the proper CMake variables are used to support this use case.