### PR TITLE
microatf: ensure that struct atf_tc_s is large enough

### DIFF
--- a/external/microatf/src/atf-c.c
+++ b/external/microatf/src/atf-c.c
@@ -76,14 +76,16 @@ static microatf_context_t microatf_context_static;
 static microatf_context_t *microatf_context = &microatf_context_static;
 
 struct atf_tc_impl_s_ {
+	size_t variables_size;
+	size_t config_variables_size;
 	char const *variables_key[128];
 	char const *variables_value[128];
-	size_t variables_size;
 	char const *config_variables_key[128];
 	char const *config_variables_value[128];
-	size_t config_variables_size;
 	STAILQ_ENTRY(atf_tc_s) entries;
 };
+_Static_assert(sizeof(atf_tc_t) - offsetof(atf_tc_t, impl_space_) >=
+    sizeof(struct atf_tc_impl_s_), "struct atf_tc_s is too small");
 
 atf_error_t
 atf_tc_set_md_var(atf_tc_t *tc, char const *key, char const *value, ...)

--- a/external/microatf/src/atf-c.h
+++ b/external/microatf/src/atf-c.h
@@ -36,12 +36,13 @@ typedef struct atf_tc_s atf_tc_t;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wpedantic"
+#define ATF_IMPL_SIZE (2 * sizeof(size_t) + 513 * sizeof(void*))
 struct atf_tc_s {
-	MICROATF_ALIGNAS(8192) char const *name;
+	char const *name;
 	void (*head)(atf_tc_t *);
 	void (*body)(atf_tc_t const *);
 	struct atf_tc_impl_s_ *impl_;
-	MICROATF_ALIGNAS(max_align_t) unsigned char impl_space_[];
+	MICROATF_ALIGNAS(max_align_t) unsigned char impl_space_[ATF_IMPL_SIZE];
 };
 #pragma GCC diagnostic pop
 
@@ -143,6 +144,7 @@ void atf_tc_skip(const char *reason, ...);
 		NULL,                                          \
 		microatf_tc_##tc##_body,                       \
 		NULL,                                          \
+		{}                                             \
 	}
 
 #define ATF_TC(tc)                                             \
@@ -153,6 +155,7 @@ void atf_tc_skip(const char *reason, ...);
 		microatf_tc_##tc##_head,                       \
 		microatf_tc_##tc##_body,                       \
 		NULL,                                          \
+		{}                                             \
 	}
 
 #define ATF_TC_HEAD(tc, tcptr)               \


### PR DESCRIPTION
When running the tests on a CheriBSD system on Arm Morello, pointers are 16 bytes, so the implicit size of 8192 bytes is not large enough to hold all of struct atf_tc_impl_s_ and running the tests fails with a bounds violation. To fix this issue, this commit explicitly sizes the array instead of relying on the alignment and adds a static assertion to the source file to ensure this invariant holds. I've also reordered struct atf_tc_impl_s_ to avoid padding on CHERI systems.