### PR TITLE
Don't run target executables during build when cross-compiling

### DIFF
--- a/external/microatf/cmake/ATFTest.cmake
+++ b/external/microatf/cmake/ATFTest.cmake
@@ -16,6 +16,11 @@ function(atf_discover_tests _target)
     TARGET "${_target}"
     PROPERTY CROSSCOMPILING_EMULATOR)
 
+  if(CMAKE_CROSSCOMPILING AND NOT _test_executor)
+    message(WARNING "Cannot detect tests for ${_target} without CROSSCOMPILING_EMULATOR")
+    return()
+  endif()
+
   add_custom_command(
     TARGET ${_target}
     POST_BUILD


### PR DESCRIPTION
Trying to run the test executables during the build to get the list of test cases causes my cross-compilation to fail. Skip adding the test cases to CTest in that case (but still build them we can run them manually).