### PR TITLE
Check errno on startup in timerfd__{reset_to_very_long,unmodified_errno}

### DIFF
--- a/test/timerfd-test.c
+++ b/test/timerfd-test.c
@@ -952,6 +952,7 @@ check:
 ATF_TC_WITHOUT_HEAD(timerfd__unmodified_errno);
 ATF_TC_BODY_FD_LEAKCHECK(timerfd__unmodified_errno, tc)
 {
+	ATF_REQUIRE(errno == 0);
 	int timerfd = timerfd_create(CLOCK_MONOTONIC, /**/
 	    TFD_CLOEXEC | TFD_NONBLOCK);
 	ATF_REQUIRE(timerfd >= 0);
@@ -963,6 +964,7 @@ ATF_TC_BODY_FD_LEAKCHECK(timerfd__unmodified_errno, tc)
 			    .it_value.tv_nsec = 100000000,
 			},
 			NULL) == 0);
+	ATF_REQUIRE(errno == 0);
 	(void)wait_for_timerfd(timerfd);
 	ATF_REQUIRE(errno == 0);
 
@@ -989,6 +991,7 @@ ATF_TC_BODY_FD_LEAKCHECK(timerfd__unmodified_errno, tc)
 ATF_TC_WITHOUT_HEAD(timerfd__reset_to_very_long);
 ATF_TC_BODY_FD_LEAKCHECK(timerfd__reset_to_very_long, tc)
 {
+	ATF_REQUIRE(errno == 0);
 	int timerfd = timerfd_create(CLOCK_MONOTONIC, /**/
 	    TFD_CLOEXEC | TFD_NONBLOCK);
 	ATF_REQUIRE(timerfd >= 0);


### PR DESCRIPTION
Due to a bug in CheriBSD, errno was set non-zero when starting this test, but without these checks the test confusingly failed in the later check which made me think something was wrong in timerfd_create. Check errno on startup to make this more obvious.

See https://github.com/CTSRD-CHERI/cheribsd/issues/1424