### PR TITLE
Add support for CheriBSD

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(wrap OBJECT wrap.c)
 set_property(TARGET wrap PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(wrap PUBLIC Threads::Threads)
 target_include_directories(wrap
+                           PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
                            PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>)
 
 macro(add_compat_target _name _condition)
@@ -51,6 +52,8 @@ include(CheckSymbolExists)
 # supports native timerfd descriptors. Prefer them if available.
 check_symbol_exists(eventfd "sys/eventfd.h" HAVE_EVENTFD)
 check_symbol_exists(timerfd_create "sys/timerfd.h" HAVE_TIMERFD)
+# Presence of a variadic version of fcntl allows for safer interposing.
+check_symbol_exists(vfcntl "fcntl.h;stdarg.h" HAVE_VFCNTL)
 
 check_symbol_exists(kqueue1 "sys/types.h;sys/event.h;sys/time.h" HAVE_KQUEUE1)
 add_compat_target(kqueue1 "NOT;HAVE_KQUEUE1")
@@ -117,9 +120,9 @@ target_link_libraries(
           $<BUILD_INTERFACE:compat_enable_sigops>
           $<BUILD_INTERFACE:rwlock>
           $<BUILD_INTERFACE:wrap>)
-if(HAVE_TIMERFD)
-  target_compile_definitions(epoll-shim PRIVATE HAVE_TIMERFD)
-endif()
+configure_file(
+  epoll_shim_config.h.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/epoll_shim_config.h)
 target_compile_definitions(epoll-shim PRIVATE EPOLL_SHIM_DISABLE_WRAPPER_MACROS)
 target_include_directories(
   epoll-shim

--- a/src/epoll_shim_config.h.cmake
+++ b/src/epoll_shim_config.h.cmake
@@ -1,0 +1,3 @@
+#cmakedefine01 HAVE_TIMERFD
+#cmakedefine01 HAVE_VFCNTL
+

--- a/src/epoll_shim_ctx.h
+++ b/src/epoll_shim_ctx.h
@@ -4,6 +4,7 @@
 #include <sys/tree.h>
 
 #include <stdatomic.h>
+#include <stdarg.h>
 
 #include <signal.h>
 #include <unistd.h>
@@ -83,5 +84,6 @@ int epoll_shim_ppoll(struct pollfd *, nfds_t, struct timespec const *,
     sigset_t const *);
 
 int epoll_shim_fcntl(int fd, int cmd, ...);
+int epoll_shim_vfcntl(int fd, int cmd, va_list);
 
 #endif

--- a/src/epoll_shim_interpose.c
+++ b/src/epoll_shim_interpose.c
@@ -6,14 +6,7 @@
 #include <unistd.h>
 
 #include "epoll_shim_interpose_export.h"
-
-int epoll_shim_close(int fd);
-ssize_t epoll_shim_read(int fd, void *buf, size_t nbytes);
-ssize_t epoll_shim_write(int fd, void const *buf, size_t nbytes);
-int epoll_shim_poll(struct pollfd *, nfds_t, int);
-int epoll_shim_ppoll(struct pollfd *, nfds_t, struct timespec const *,
-    sigset_t const *);
-int epoll_shim_fcntl(int fd, int cmd, ...);
+#include "epoll_shim_ctx.h"
 
 EPOLL_SHIM_INTERPOSE_EXPORT
 ssize_t
@@ -65,8 +58,7 @@ fcntl(int fd, int cmd, ...)
 	va_list ap;
 
 	va_start(ap, cmd);
-	void *arg = va_arg(ap, void *);
-	int rv = epoll_shim_fcntl(fd, cmd, arg);
+	int rv = epoll_shim_vfcntl(fd, cmd, ap);
 	va_end(ap);
 
 	return rv;

--- a/src/timerfd_ctx.c
+++ b/src/timerfd_ctx.c
@@ -614,7 +614,7 @@ timerfd_ctx_read(TimerFDCtx *timerfd, int kq, uint64_t *value)
 	}
 
 	bool got_kevent = false;
-	unsigned long event_ident;
+	uintptr_t event_ident;
 	{
 		struct kevent kevs[3];
 		int n = kevent(kq, NULL, 0, kevs, 3,

--- a/src/wrap.h
+++ b/src/wrap.h
@@ -3,6 +3,7 @@
 
 #include <poll.h>
 #include <signal.h>
+#include <stdarg.h>
 #include <stddef.h>
 #include <time.h>
 #include <unistd.h>
@@ -15,5 +16,6 @@ int real_ppoll(struct pollfd fds[], nfds_t nfds,
     struct timespec const *restrict timeout,
     sigset_t const *restrict newsigmask);
 int real_fcntl(int fd, int cmd, ...);
+int real_vfcntl(int fd, int cmd, va_list ap);
 
 #endif

--- a/test/epoll-test.c
+++ b/test/epoll-test.c
@@ -378,7 +378,12 @@ ATF_TC_BODY_FD_LEAKCHECK(epoll__event_size, tc)
 	struct epoll_event event;
 	// this check works on 32bit _and_ 64bit, since
 	// sizeof(epoll_event) == sizeof(uint32_t) + sizeof(uint64_t)
+#if __SIZEOF_POINTER__ <= 8
 	ATF_REQUIRE(sizeof(event) == 12);
+#else
+	/* On systems with 128-bit pointers, it will be padded to 32 bytes */
+	ATF_REQUIRE(sizeof(event) == 2 * sizeof(void*));
+#endif
 }
 
 ATF_TC_WITHOUT_HEAD(epoll__recursive_register);
@@ -1232,7 +1237,9 @@ ATF_TC_BODY_FD_LEAKCHECK(epoll__epollpri, tcptr)
 	fd_tcp_socket(fds);
 
 	ATF_REQUIRE(fcntl(fds[0], F_SETFL, O_NONBLOCK) == 0);
+	ATF_REQUIRE(fcntl(fds[0], F_GETFL) & O_NONBLOCK);
 	ATF_REQUIRE(fcntl(fds[1], F_SETFL, O_NONBLOCK) == 0);
+	ATF_REQUIRE(fcntl(fds[1], F_GETFL) & O_NONBLOCK);
 
 	int ep = epoll_create1(EPOLL_CLOEXEC);
 	ATF_REQUIRE(ep >= 0);


### PR DESCRIPTION
I tried running the tests on my Morello board and noticed that most of them were failing. This patch series makes epoll-shim work correctly when running on [CheriBSD](https://github.com/CTSRD-CHERI/cheribsd) (a fork of FreeBSD that adds support for CHERI-enabled architectures such as CHERI-RISC-V and Arm Morello).

With this patch series all but two tests pass for me and the last remaining failures will go away once https://github.com/CTSRD-CHERI/cheribsd/issues/1424 has been fixed.

This supersedes https://github.com/jiixyj/epoll-shim/pull/36 and all the commits in that PR have been split out into separate changes.

Depends on https://github.com/CTSRD-CHERI/cheribsd/pull/2194